### PR TITLE
Use babel-core polyfill for Safari.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
   devtool: 'source-map',
   entry: [
     'webpack-hot-middleware/client',
+    'babel-core/polyfill',
     './index'
   ],
   output: {

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -4,7 +4,10 @@ var path = require("path");
 var webpack = require("webpack");
 
 module.exports = {
-  entry: "./index",
+  entry: [
+    "babel-core/polyfill",
+    "./index"
+  ],
   output: {
     path: path.join(__dirname, "dist"),
     filename: "bundle.js",


### PR DESCRIPTION
Safari lacks es6 Object.assign. This uses the solution from
http://stackoverflow.com/a/32917654 to add the babel-core polyfill which
fixes support for Safari (and potentially other polyfills?).

This is the same fix from https://github.com/FormidableLabs/spectacle/pull/130.