### PR TITLE
Add instructions for running on windows

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,28 @@ Then, to start up the local server, run `npm start`
 
 Open a browser and hit [http://localhost:3000](http://localhost:3000), and we are ready to roll
 
+### On Windows
+
+On Windows you might get an error saying
+
+```
+'NODE_ENV' is not recognized as an internal or external command,
+operable program or batch file.
+```
+
+Thus, modify the npm scripts in `package.json` to properly set the `NODE_ENV` environment variable:
+
+```json
+...
+"scripts": {
+    ...
+    "build": "SET NODE_ENV=production & webpack --config webpack.config.production.js",
+    ...
+    "start": "SET NODE_ENV=development & node server.js"
+},
+...
+```
+
 ## Build & Deployment
 
 Building the dist version of the project is as easy as running `npm run build`


### PR DESCRIPTION
Hi,

I just wanted to launch it on my Win7 PC and it won't work due to how the `NODE_ENV` variable is set in `package.json`. Just added a note for that on the README so that others can quickly fix it.