### PR TITLE
Adds dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "express": "^4.13.3",
     "file-loader": "^0.8.4",
     "html-loader": "^0.4.0",
+    "is-buffer": "^1.1.1",
     "markdown-loader": "^0.1.7",
     "node-libs-browser": "^0.5.3",
     "raw-loader": "^0.5.1",


### PR DESCRIPTION
The current boilerplate does not not specify the `is-buffer` dependency.  

This causes on error on `npm start`