### PR TITLE
add cross-env

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,26 +14,6 @@ Then, to start up the local server, run `npm start`
 
 Open a browser and hit [http://localhost:3000](http://localhost:3000), and we are ready to roll
 
-### On Windows
-
-On Windows you might get an error saying
-
-```
-'NODE_ENV' is not recognized as an internal or external command,
-operable program or batch file.
-```
-
-Thus, modify the npm scripts in `package.json` to properly set the `NODE_ENV` environment variable:
-
-```json
-...
-"scripts": {
-    "build": "SET NODE_ENV=production & webpack --config webpack.config.production.js",
-    "start": "SET NODE_ENV=development & node server.js"
-},
-...
-```
-
 ## Build & Deployment
 
 Building the dist version of the project is as easy as running `npm run build`

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "lib/index.js",
   "scripts": {
     "clean": "rimraf dist",
-    "build": "NODE_ENV=production webpack --config webpack.config.production.js",
+    "build": "cross-env NODE_ENV=production webpack --config webpack.config.production.js",
     "lint": "eslint --ext .js,.jsx .",
     "deploy": "npm run clean & npm run build && surge -p .",
-    "start": "NODE_ENV=development node server.js"
+    "start": "cross-env NODE_ENV=development node server.js"
   },
   "author": "",
   "license": "MIT",
@@ -28,6 +28,7 @@
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.0.1",
     "babel-preset-stage-0": "^6.3.13",
+    "cross-env": "^1.0.7",
     "css-loader": "^0.23.0",
     "eslint": "^1.8.0",
     "eslint-config-defaults": "^7.1.1",


### PR DESCRIPTION
Doing 'set Node_ENV...' for some reason doesn't work on Widnows for this repo.. It just autoamtically kicks out of the process without an error or anything.

Using cross-env prevents this it looks like.

See screenshot for what I mean I took:
![crossenvspectacle](https://cloud.githubusercontent.com/assets/6899011/14230212/880ff358-f913-11e5-93de-3e749799b191.jpg)
