### PR TITLE
remove dist from ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .DS_Store
 node_modules
 npm-debug.log
-dist


### PR DESCRIPTION
Why? Because I think the most convenient way of hosting your spectacle presentation is on github. It would make sense to have the boilerplate set up for that usecase I think. So one other thing I would do, is to create a gh-pages branch and remove the master branch.

What do you think? 
