### PR TITLE
Add react-transform-hmr plugin to babel-loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,9 +19,6 @@ module.exports = {
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin()
   ],
-  node: {
-    fs: 'empty'
-  },
   module: {
     loaders: [{
       test: /\.md$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,9 @@ module.exports = {
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin()
   ],
+  node: {
+    fs: 'empty'
+  },
   module: {
     loaders: [{
       test: /\.md$/,
@@ -28,7 +31,18 @@ module.exports = {
       exclude: /node_modules/,
       loader: "babel-loader",
       query: {
-        presets: ['es2015', 'react']
+        presets:['react', 'es2015'],
+        env: {
+          development: {
+            plugins: [["react-transform", {
+              transforms: [{
+                transform: "react-transform-hmr",
+                imports: ["react"],
+                locals: ["module"]
+              }]
+            }]]
+          }
+        }
       }
     }, {
       test: /\.css$/,


### PR DESCRIPTION
Hot reload was broken on `presentation/index.js` edition, and I had this warning : 
```
[HMR] The following modules couldn't be hot updated: (Full reload needed)
This is usually because the modules which have changed (and their parents) 
do not know how to hot reload themselves. 
See http://webpack.github.io/docs/hot-module-replacement-with-webpack.html 
for more details.
[HMR]  - ./presentation/index.js
``` 

The add of `react-transform-hmr` plugin to babel-loader configuration fix the issue.