### PR TITLE
Allow serving local static files

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,9 +17,7 @@ app.use(require("webpack-dev-middleware")(compiler, {
 
 app.use(require("webpack-hot-middleware")(compiler));
 
-app.get("*", function(req, res) {
-  res.sendFile(path.join(__dirname, "index.html"));
-});
+app.use(express.static('./'));
 
 app.listen(serverPort, "localhost", function (err) {
   if (err) {


### PR DESCRIPTION
Currently it's not possible to load static CSS/JS files from local by adding a tag in `index.html` because Express always returns `index.html`.