### PR TITLE
Don't hardcode the server's hostname

### DIFF
--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ app.get("*", function(req, res) {
   res.sendFile(path.join(__dirname, "index.html"));
 });
 
-app.listen(serverPort, "localhost", function (err) {
+app.listen(serverPort, function (err) {
   if (err) {
     console.log(err);
     return;


### PR DESCRIPTION
This fixes a usability bug where the server is run inside of a Docker container (and probably also when inside of VM?). Since the container is run on a different IP the server wouldn't listen to any incoming requests.

This does come with the downside that the server will now accept connections on any IP address.

-----

In case anyone is interested, this is the `docker-compose.yml` file that I'm using to install and serve my slides:

```yml
version: '2'

services:
  npm:
    image: node:6
    volumes:
      - .:/usr/src/app
    working_dir: /usr/src/app
    ports:
      - "3000:3000"
    command: [npm, run, start]
```