### PR TITLE
Add netlify deploy option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,3 +19,8 @@ Open a browser and hit [http://localhost:3000](http://localhost:3000), and we ar
 Building the dist version of the project is as easy as running `npm run build`
 
 If you want to deploy the slideshow to surge, run `npm run deploy`
+
+Click to deploy to Netlify
+
+<!-- Markdown snippet -->
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/FormidableLabs/spectacle-boilerplate)

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run clean && npm run build"
+  publish = "/"


### PR DESCRIPTION
Hello @kenwheeler and Formidable team. Big fan of your open source work, primarily [react-music](https://github.com/FormidableLabs/react-music).

# What is this?
I saw Kyle from Gatsby use this for his GraphQL Summit talk and was curious what he use for his slides and have finally stumbled onto this project. I am about use this for a talk next month, but wanted to reach out to provide a Netlify solution for deployment.

Netlify has a [CLI](https://github.com/netlify/netlify-cli) similar to surge but it seems redundant to also add that unless you disagree. Netlify does differ by offering git integration to your repo and will watch for changes and deploy them to production (similar to github pages, except they are atomic). 

There is a pretty cool [Open Source](https://www.netlify.com/open-source/) plan as well which more features.

# Solution

I added a deploy to Netlify button to the README. Feel free to test it out below. The toml file just tells Netlify that your index.html is in the root and your build command is `npm run clean && npm run build`.

<!-- Markdown snippet -->
[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/bdougie/spectacle-boilerplate)

Let me know if you have questions. 