### PR TITLE
Fix link to API docs in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 ## Reference
 
-The Spectacle core API is available at [https://github.com/FormidableLabs/spectacle/blob/master/README.markdown](https://github.com/FormidableLabs/spectacle/blob/master/README.markdown).
+The Spectacle core API is available at [https://github.com/FormidableLabs/spectacle/blob/master/README.md](https://github.com/FormidableLabs/spectacle/blob/master/README.md).
 
 ## Development
 


### PR DESCRIPTION
The link was pointing to a README.markdown in the 
base spectacle repo, this file has been renamed to
README.md.

This PR updates the link to link to the renamed README.