### PR TITLE
Set babel-loader cacheDirectory to true.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,8 +27,11 @@ module.exports = {
     }, {
       test: /\.(js|jsx)$/,
       exclude: /node_modules/,
-      loader: "babel-loader",
-      include: __dirname
+      include: __dirname,
+      use: {
+        options: { cacheDirectory: true },
+        loader: "babel-loader",
+      }
     }, {
       test: /\.css$/,
       loaders: ["style-loader", "raw-loader"],


### PR DESCRIPTION
> We do this to avoid potentially expensive Babel recompilation.

> Depending on the change, we can get up to 2x speed improvements on rebuilds.

https://github.com/babel/babel-loader/

We don't see too much improvement in the small example, but as we add more slides the cache helps.