### PR TITLE
Remove size prop from Text on first slide

### DIFF
--- a/presentation/index.js
+++ b/presentation/index.js
@@ -38,7 +38,7 @@ export default class Presentation extends React.Component {
           <Heading size={1} fit caps lineHeight={1} textColor="secondary">
             Spectacle Boilerplate
           </Heading>
-          <Text margin="10px 0 0" textColor="tertiary" size={1} fit bold>
+          <Text margin="10px 0 0" textColor="tertiary" fit bold>
             open the presentation/index.js file to get started
           </Text>
         </Slide>


### PR DESCRIPTION
The example sets a size prop on Text which is not supported.